### PR TITLE
request function with interface arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ func main() {
     ctx := context.Background()
 
     // Create a basicAuth client
-    client := btcpay.CreateBasicClient("https://mybtcpayserver.com", "myUsername", "myPassword")
+    client := btcpay.NewBasicClient("https://mybtcpayserver.com", "myUsername", "myPassword")
 
     // Print informations about the server, etc
     fmt.Println(client.GetServerInfo(ctx))
 
     // Does the same but with an APIKey instead of basicAuth
     // Create a client with an APIKey
-    client2 := btcpay.CreateBasicClient("https://mybtcpayserver.com", btcpay.APIKey("myAPIKey")
+    client2 := btcpay.NewClient("https://mybtcpayserver.com", btcpay.APIKey("myAPIKey")
 
     // Print informations about the server, etc again but use the APIKey based client
     fmt.Println(client2.GetServerInfo(ctx))
@@ -102,7 +102,7 @@ Endpoint                                                                   |    
 |`/api/v1/stores/{storeId}/payment-requests                              ` | ✅ Fully implemented
 |`/api/v1/stores/{storeId}/pull-payments`                                  | ✅ Fully implemented
 |`/api/v1/stores/{storeId}/payment-methods/OnChain/{cryptoCode}/wallet`    | ⏳ Work in progress
-|`/misc/lang`                                                              | ❌ Not working, [issue](https://github.com/btcpayserver/btcpayserver/issues/2437)
+|`/misc/lang`                                                              | ✅ Fully implemented
 |`/i`                                                                      | ✅ Fully implemented
 |`/api/v1/pull-payments`                                                   | ✅ Fully implemented
 

--- a/api_keys.go
+++ b/api_keys.go
@@ -1,91 +1,45 @@
 package btcpay
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) RevokeAPIKey(ctx context.Context, apiKey *APIKey) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/api-keys/%s", c.URL, *apiKey)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := c.doRequest(req)
+	statusCode, err := c.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
 	return statusCode, nil
 }
 
-type APIKeyResponse struct {
-	APIKey      APIKey             `json:"apiKey"`
-	Label       string             `json:"label"`
-	Permissions []BTCPayPermission `json:"permissions"`
-}
-
 func (c *Client) GetCurrentAPIKey(ctx context.Context) (*APIKeyResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/api-keys/current", c.URL)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes APIKeyResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes APIKeyResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (c *Client) RevokeCurrentAPIKey(ctx context.Context) (*APIKeyResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/api-keys/current", c.URL)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes APIKeyResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "DELETE", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
 	}
-	var data APIKeyResponse
-	err = json.Unmarshal(bytes, &data)
-	if err != nil {
-		return nil, 0, err
-	}
-	return &data, statusCode, nil
-}
-
-type APIKeyRequest struct {
-	Label       string             `json:"label,omitempty"`
-	Permissions []BTCPayPermission `json:"permissions,omitempty"`
+	return &dataRes, statusCode, nil
 }
 
 func (c *Client) CreateAPIKey(ctx context.Context, apiKeyRequest *APIKeyRequest) (*APIKeyResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/api-keys", c.URL)
-	dataReq, err := json.Marshal(apiKeyRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes APIKeyResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "POST", &dataRes, apiKeyRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes APIKeyResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }

--- a/authentication.go
+++ b/authentication.go
@@ -2,6 +2,7 @@ package btcpay
 
 import "fmt"
 
+// Enums BTCPayPermission
 type BTCPayPermission string
 
 type Permission struct {

--- a/authorization.go
+++ b/authorization.go
@@ -1,35 +1,15 @@
 package btcpay
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
-// WIP, needs testing
-
-type AuthorizationRequest struct {
-	Permissions           []BTCPayPermission `json:"permissions,omitempty"`
-	ApplicationName       string             `json:"applicationName,omitempty"`
-	Strict                bool               `json:"strict,omitempty"`
-	SelectiveStores       bool               `json:"selectiveStores,omitempty"`
-	Redirect              string             `json:"redirect,omitempty"`
-	ApplicationIdentifier string             `json:"applicationIdentifier,omitempty"`
-}
+// !Needs testing
 
 func (c *Client) Authorize(ctx context.Context, authRequest *AuthorizationRequest) (int, error) {
 	endpoint := fmt.Sprintf("%s/api-keys/authorize", c.URL)
-	dataReq, err := json.Marshal(authRequest)
-	if err != nil {
-		return 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := c.doRequest(req)
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", nil, authRequest)
 	if err != nil {
 		return statusCode, err
 	}

--- a/btcpay_enums.go
+++ b/btcpay_enums.go
@@ -1,0 +1,154 @@
+package btcpay
+
+// Enums SpeedPolicy
+type BTCPaySpeedPolicy string
+
+type SpeedPolicy struct {
+	HighSpeed      BTCPaySpeedPolicy
+	MediumSpeed    BTCPaySpeedPolicy
+	LowMediumSpeed BTCPaySpeedPolicy
+	LowSpeed       BTCPaySpeedPolicy
+}
+
+func GetSpeedPolicy() *SpeedPolicy {
+	return &SpeedPolicy{
+		HighSpeed:      "HighSpeed",
+		MediumSpeed:    "MediumSpeed",
+		LowMediumSpeed: "LowMediumSpeed",
+		LowSpeed:       "LowSpeed",
+	}
+}
+
+// Enums InvoiceStatus
+type BTCPayInvoiceStatus string
+
+type InvoiceStatus struct {
+	New        BTCPayInvoiceStatus
+	Processing BTCPayInvoiceStatus
+	Expired    BTCPayInvoiceStatus
+	Invalid    BTCPayInvoiceStatus
+	Settled    BTCPayInvoiceStatus
+}
+
+func GetInvoiceStatus() *InvoiceStatus {
+	return &InvoiceStatus{
+		New:        "New",
+		Processing: "Processing",
+		Expired:    "Expired",
+		Invalid:    "Invalid",
+		Settled:    "Settled",
+	}
+}
+
+// Enums InvoiceAdditionalStatus
+type BTCPayInvoiceAdditionalStatus string
+
+type InvoiceAdditionalStatus struct {
+	None        BTCPayInvoiceAdditionalStatus
+	PaidLate    BTCPayInvoiceAdditionalStatus
+	PaidPartial BTCPayInvoiceAdditionalStatus
+	Marked      BTCPayInvoiceAdditionalStatus
+	AddInvalid  BTCPayInvoiceAdditionalStatus
+	PaidOver    BTCPayInvoiceAdditionalStatus
+}
+
+func GetInvoiceAdditionalStatus() *InvoiceAdditionalStatus {
+	return &InvoiceAdditionalStatus{
+		None:        "None",
+		PaidLate:    "PaidLate",
+		PaidPartial: "PaidPartial",
+		Marked:      "Marked",
+		AddInvalid:  "Invalid",
+		PaidOver:    "PaidOver",
+	}
+
+}
+
+// Enums InvoiceStatusMark
+type BTCPayInvoiceStatusMark string
+
+type InvoiceStatusMark struct {
+	MarkInvalid  BTCPayInvoiceStatusMark
+	MarkComplete BTCPayInvoiceStatusMark
+}
+
+func GetInvoiceStatusMark() *InvoiceStatusMark {
+	return &InvoiceStatusMark{
+		MarkInvalid:  "Invalid",
+		MarkComplete: "Complete",
+	}
+}
+
+// Enums PaymentStatus
+type BTCPayPaymentStatus string
+
+type PaymentStatus struct {
+	New        BTCPayPaymentStatus
+	Processing BTCPayPaymentStatus
+	Expired    BTCPayPaymentStatus
+	Invalid    BTCPayPaymentStatus
+	Settled    BTCPayPaymentStatus
+}
+
+func GetPaymentStatus() *PaymentStatus {
+	return &PaymentStatus{
+		Processing: "Processing",
+		Invalid:    "Invalid",
+		Settled:    "Settled",
+	}
+}
+
+// Enums PaymentRequestStatus
+type BTCPayPaymentRequestStatus string
+
+type PaymentRequestStatus struct {
+	Pending   BTCPayInvoiceStatus
+	Completed BTCPayInvoiceStatus
+	Expired   BTCPayInvoiceStatus
+}
+
+func GetPaymentRequestStatus() *PaymentRequestStatus {
+	return &PaymentRequestStatus{
+		Pending:   "Pending",
+		Completed: "Completed",
+		Expired:   "Expired",
+	}
+}
+
+// Enums NetworkFeeMode
+type BTCPayPayoutStatus string
+
+type PayoutStatus struct {
+	AwaitingApproval BTCPayPayoutStatus
+	AwaitingPayment  BTCPayPayoutStatus
+	InProgress       BTCPayPayoutStatus
+	Completed        BTCPayPayoutStatus
+	Cancelled        BTCPayPayoutStatus
+}
+
+func GetPayoutStatus() *PayoutStatus {
+	return &PayoutStatus{
+		AwaitingApproval: "AwaitingApproval",
+		AwaitingPayment:  "AwaitingPayment",
+		InProgress:       "InProgress",
+		Completed:        "Completed",
+		Cancelled:        "Cancelled",
+	}
+}
+
+// Enums NetworkFeeMode
+type BTCPayNetworkFeeMode string
+
+type NetworkFeeMode struct {
+	MultiplePaymentsOnly BTCPayNetworkFeeMode
+	Always               BTCPayNetworkFeeMode
+	Never                BTCPayNetworkFeeMode
+}
+
+func GetNetworkFeeMode() *NetworkFeeMode {
+	return &NetworkFeeMode{
+		MultiplePaymentsOnly: "MultiplePaymentsOnly",
+		Always:               "Always",
+		Never:                "Never",
+	}
+}

--- a/btcpay_types.go
+++ b/btcpay_types.go
@@ -1,0 +1,352 @@
+package btcpay
+
+import "net/http"
+
+type APIKey string
+
+type Client struct {
+	URL            string
+	APIKey         APIKey
+	Username       string
+	Password       string
+	Http           *http.Client
+	Store          *Store
+	Invoice        *Invoice
+	PaymentRequest *PaymentRequest
+	Notification   *Notification
+	PullPayment    *PullPayment
+	Payout         *Payout
+}
+
+type APIKeyRequest struct {
+	Label       string             `json:"label,omitempty"`
+	Permissions []BTCPayPermission `json:"permissions,omitempty"`
+}
+type APIKeyResponse struct {
+	APIKey      APIKey             `json:"apiKey"`
+	Label       string             `json:"label"`
+	Permissions []BTCPayPermission `json:"permissions"`
+}
+
+type AuthorizationRequest struct {
+	Permissions           []BTCPayPermission `json:"permissions,omitempty"`
+	ApplicationName       string             `json:"applicationName,omitempty"`
+	Strict                bool               `json:"strict,omitempty"`
+	SelectiveStores       bool               `json:"selectiveStores,omitempty"`
+	Redirect              string             `json:"redirect,omitempty"`
+	ApplicationIdentifier string             `json:"applicationIdentifier,omitempty"`
+}
+
+type HealthResponse struct {
+	Synchronized bool `json:"synchronized"`
+}
+
+type InvoiceID string
+
+type Invoice struct {
+	Store  *Store
+	Client *Client
+	ID     InvoiceID
+}
+
+type InvoiceResponse struct {
+	Amount           string                        `json:"amount,omitempty"`
+	Currency         string                        `json:"currency,omitempty"`
+	Metadata         InvoiceMetadata               `json:"metadata,omitempty"`
+	Checkout         InvoiceCheckout               `json:"checkout,omitempty"`
+	ID               InvoiceID                     `json:"id"`
+	CheckoutLink     string                        `json:"checkoutLink"`
+	CreatedTime      int64                         `json:"createdTime"`
+	ExpirationTime   int64                         `json:"expirationTime"`
+	MonitoringTime   int64                         `json:"monitoringTime"`
+	Status           BTCPayInvoiceStatus           `json:"status"`
+	AdditionalStatus BTCPayInvoiceAdditionalStatus `json:"additionalStatus"`
+}
+
+type InvoiceMetadata map[string]interface{}
+
+type InvoiceCheckout struct {
+	SpeedPolicy       BTCPaySpeedPolicy `json:"speedPolicy,omitempty"`
+	PaymentMethods    []string          `json:"paymentMethods,omitempty"`
+	ExpirationMinutes int               `json:"expirationMinutes,omitempty"`
+	MonitoringMinutes int               `json:"monitoringMinutes,omitempty"`
+	PaymentTolerance  float64           `json:"paymentTolerance,omitempty"`
+	RedirectURL       string            `json:"redirectURL,omitempty"`
+	DefaultLanguage   string            `json:"defaultLanguage,omitempty"`
+}
+
+type InvoiceRequest struct {
+	Amount          string          `json:"amount"`
+	Currency        string          `json:"currency,omitempty"`
+	Metadata        InvoiceMetadata `json:"metadata,omitempty"`
+	InvoiceCheckout InvoiceCheckout `json:"checkout,omitempty"`
+}
+
+type InvoiceUpdate struct {
+	Metadata InvoiceMetadata `json:"metadata,omitempty"`
+}
+
+type PaymentID string
+
+type Payment struct {
+	ID           PaymentID           `json:"id"`
+	ReceivedDate int64               `json:"receivedDate"`
+	Value        string              `json:"value"`
+	Fee          string              `json:"fee"`
+	Status       BTCPayPaymentStatus `json:"status"`
+	Destination  string              `json:"destination"`
+}
+
+type InvoicePaymentMethodResponse struct {
+	PaymentMethod     string    `json:"paymentMethod"`
+	Destination       string    `json:"destination"`
+	PaymentLink       string    `json:"paymentLink,omitempty"`
+	Rate              string    `json:"rate"`
+	PaymentMethodPaid string    `json:"paymentMethodPaid"`
+	TotalPaid         string    `json:"totalPaid"`
+	Due               string    `json:"due"`
+	Amount            string    `json:"amount"`
+	NetworkFee        string    `json:"networkFee"`
+	Payments          []Payment `json:"payments"`
+}
+
+type MarkInvoiceStatusRequest struct {
+	Status BTCPayInvoiceStatusMark `json:"status"`
+}
+
+type LanguageCodesRespose struct {
+	Code            string `json:"code"`
+	CurrentLanguage string `json:"currentLanguage"`
+}
+
+type InvoiceCheckoutPage struct {
+	Page []byte
+}
+
+type Notification struct {
+	ID     NotificationID
+	Client *Client
+}
+
+type NotificationID string
+
+type NotificationResponse struct {
+	ID          NotificationID `json:"id"`
+	Body        string         `json:"body"`
+	Link        string         `json:"link"`
+	CreatedTime int64          `json:"createdTime"`
+	Seen        bool           `json:"seen"`
+}
+
+type UpdateNotification struct {
+	Seen bool `json:"seen"`
+}
+
+type PaymentRequestID string
+
+type PaymentRequest struct {
+	Store  *Store
+	Client *Client
+	ID     PaymentRequestID
+}
+
+type PaymentRequestRequest struct {
+	Amount                    float64 `json:"amount"`
+	Title                     string  `json:"title"`
+	Currency                  string  `json:"currency"`
+	Email                     string  `json:"email,omitempty"`
+	Description               string  `json:"description,omitempty"`
+	ExpiryDate                int64   `json:"expiryDate,omitempty"`
+	EmbeddedCSS               string  `json:"embeddedCSS,omitempty"`
+	CustomCSSLink             string  `json:"customCSSLink,omitempty"`
+	AllowCustomPaymentAmounts bool    `json:"allowCustomPaymentAmounts,omitempty"`
+}
+
+type PaymentRequestResponse struct {
+	ID       PaymentRequestID           `json:"id"`
+	Status   BTCPayPaymentRequestStatus `json:"status"`
+	Created  string                     `json:"created"`
+	Archived bool                       `json:"archived"`
+	PaymentRequestRequest
+}
+
+type PullPaymentID string
+
+type PullPayment struct {
+	Store  *Store
+	Client *Client
+	ID     PullPaymentID
+}
+
+type PullPaymentResponse struct {
+	ID       PullPaymentID `json:"id"`
+	Name     string        `json:"name"`
+	Currency string        `json:"currency"`
+	Amount   string        `json:"amount"`
+	Period   int64         `json:"period,omitempty"`
+	Archived bool          `json:"archived"`
+	ViewLink string        `json:"viewLink"`
+}
+
+type PayoutID string
+
+type Payout struct {
+	Store  *Store
+	Client *Client
+	ID     PayoutID
+}
+
+type PullPaymentRequest struct {
+	Name           string   `json:"name,omitempty"`
+	Amount         string   `json:"amount"`
+	Currency       string   `json:"currency"`
+	Period         int64    `json:"period,omitempty"`
+	StartsAt       int64    `json:"startsAt,omitempty"`
+	ExpiresAt      int64    `json:"expiresAt,omitempty"`
+	PaymentMethods []string `json:"paymentMethods"`
+}
+
+type PayoutResponse struct {
+	ID                  PayoutID           `json:"id"`
+	Revision            int64              `json:"revision"`
+	PullPaymentID       PullPaymentID      `json:"pullPaymentId"`
+	Date                string             `json:"date"`
+	Destination         string             `json:"destination"`
+	Amount              string             `json:"amount"`
+	PaymentMethod       string             `json:"paymentMethod"`
+	PaymentMethodAmount string             `json:"paymentMethodAmount"`
+	State               BTCPayPayoutStatus `json:"state"`
+}
+
+type PayoutApproveRequest struct {
+	Revision int64  `json:"revision"`
+	RateRule string `json:"rateRule,omitempty"`
+}
+
+type PayoutRequest struct {
+	Destination   string `json:"destination"`
+	Amount        string `json:"amount"`
+	PaymentMethod string `json:"paymentMethod"`
+}
+
+type ServerInfoResponse struct {
+	Version                 string             `json:"version"`
+	Onion                   string             `json:"onion"`
+	SupportedPaymentMethods []string           `json:"supportedPaymentMethods"`
+	FullySynched            bool               `json:"fullySynched"`
+	SyncStatus              []ServerSyncStatus `json:"syncStatus"`
+}
+
+type ServerSyncStatus struct {
+	CryptoCode      string                `json:"cryptoCode"`
+	NodeInformation ServerNodeInformation `json:"nodeInformation,omitempty"`
+	ChainHeight     int64                 `json:"chainHeight"`
+	SyncHeight      int64                 `json:"syncHeight,omitempty"`
+}
+
+type ServerNodeInformation struct {
+	Headers              int64   `json:"headers"`
+	Blocks               int64   `json:"blocks"`
+	VerificationProgress float64 `json:"verificationProgress"`
+}
+
+type StoreID string
+
+type Store struct {
+	ID     StoreID
+	Client *Client
+}
+
+type StoreResponse struct {
+	Name                         string               `json:"name"`
+	Website                      string               `json:"website"`
+	InvoiceExpiration            int64                `json:"invoiceExpiration"`
+	MonitoringExpiration         int64                `json:"monitoringExpiration"`
+	SpeedPolicy                  BTCPaySpeedPolicy    `json:"speedPolicy"`
+	LightningDescriptionTemplate string               `json:"lightningDescriptionTemplate,omitempty"`
+	PaymentTolerance             float64              `json:"paymentTolerance"`
+	AnyoneCanCreateInvoice       bool                 `json:"anyoneCanCreateInvoice"`
+	RequiresRefundEmail          bool                 `json:"requiresRefundEmail"`
+	LightningAmountInSatoshi     bool                 `json:"lightningAmountInSatoshi"`
+	LightningPrivateRouteHints   bool                 `json:"lightningPrivateRouteHints"`
+	OnChainWithLnInvoiceFallback bool                 `json:"onChainWithLnInvoiceFallback"`
+	RedirectAutomatically        bool                 `json:"redirectAutomatically"`
+	ShowRecommendedFee           bool                 `json:"showRecommendedFee"`
+	RecommendedFeeBlockTarget    int32                `json:"recommendedFeeBlockTarget"`
+	DefaultLang                  string               `json:"defaultLang"`
+	CustomLogo                   string               `json:"customLogo,omitempty"`
+	CustomCSS                    string               `json:"customCSS,omitempty"`
+	HtmlTitle                    string               `json:"htmlTitle,omitempty"`
+	NetworkFeeMode               BTCPayNetworkFeeMode `json:"networkFeeMode"`
+	PayJoinEnabled               bool                 `json:"payJoinEnabled"`
+	DefaultPaymentMethod         string               `json:"defaultPaymentMethod"`
+	ID                           StoreID              `json:"id"`
+}
+
+type StoreRequest struct {
+	Name                         string               `json:"name"`
+	Website                      string               `json:"website,omitempty"`
+	InvoiceExpiration            int64                `json:"invoiceExpiration,omitempty"`
+	MonitoringExpiration         int64                `json:"monitoringExpiration,omitempty"`
+	SpeedPolicy                  BTCPaySpeedPolicy    `json:"speedPolicy,omitempty"`
+	LightningDescriptionTemplate string               `json:"lightningDescriptionTemplate,omitempty"`
+	PaymentTolerance             float64              `json:"paymentTolerance,omitempty"`
+	AnyoneCanCreateInvoice       bool                 `json:"anyoneCanCreateInvoice,omitempty"`
+	RequiresRefundEmail          bool                 `json:"requiresRefundEmail,omitempty"`
+	LightningAmountInSatoshi     bool                 `json:"lightningAmountInSatoshi,omitempty"`
+	LightningPrivateRouteHints   bool                 `json:"lightningPrivateRouteHints,omitempty"`
+	OnChainWithLnInvoiceFallback bool                 `json:"onChainWithLnInvoiceFallback,omitempty"`
+	RedirectAutomatically        bool                 `json:"redirectAutomatically,omitempty"`
+	ShowRecommendedFee           bool                 `json:"showRecommendedFee,omitempty"`
+	RecommendedFeeBlockTarget    int32                `json:"recommendedFeeBlockTarget,omitempty"`
+	DefaultLang                  string               `json:"defaultLang,omitempty"`
+	CustomLogo                   string               `json:"customLogo,omitempty"`
+	CustomCSS                    string               `json:"customCSS,omitempty"`
+	HtmlTitle                    string               `json:"htmlTitle,omitempty"`
+	NetworkFeeMode               BTCPayNetworkFeeMode `json:"networkFeeMode,omitempty"`
+	PayJoinEnabled               bool                 `json:"payJoinEnabled,omitempty"`
+	DefaultPaymentMethod         string               `json:"defaultPaymentMethod,omitempty"`
+}
+
+type StoreUpdate struct {
+	Name                         string               `json:"name,omitempty"`
+	Website                      string               `json:"website,omitempty"`
+	InvoiceExpiration            int64                `json:"invoiceExpiration,omitempty"`
+	MonitoringExpiration         int64                `json:"monitoringExpiration,omitempty"`
+	SpeedPolicy                  BTCPaySpeedPolicy    `json:"speedPolicy,omitempty"`
+	LightningDescriptionTemplate string               `json:"lightningDescriptionTemplate,omitempty"`
+	PaymentTolerance             float64              `json:"paymentTolerance,omitempty"`
+	AnyoneCanCreateInvoice       bool                 `json:"anyoneCanCreateInvoice,omitempty"`
+	RequiresRefundEmail          bool                 `json:"requiresRefundEmail,omitempty"`
+	LightningAmountInSatoshi     bool                 `json:"lightningAmountInSatoshi,omitempty"`
+	LightningPrivateRouteHints   bool                 `json:"lightningPrivateRouteHints,omitempty"`
+	OnChainWithLnInvoiceFallback bool                 `json:"onChainWithLnInvoiceFallback,omitempty"`
+	RedirectAutomatically        bool                 `json:"redirectAutomatically,omitempty"`
+	ShowRecommendedFee           bool                 `json:"showRecommendedFee,omitempty"`
+	RecommendedFeeBlockTarget    int32                `json:"recommendedFeeBlockTarget,omitempty"`
+	DefaultLang                  string               `json:"defaultLang,omitempty"`
+	CustomLogo                   string               `json:"customLogo,omitempty"`
+	CustomCSS                    string               `json:"customCSS,omitempty"`
+	HtmlTitle                    string               `json:"htmlTitle,omitempty"`
+	NetworkFeeMode               BTCPayNetworkFeeMode `json:"networkFeeMode,omitempty"`
+	PayJoinEnabled               bool                 `json:"payJoinEnabled,omitempty"`
+	DefaultPaymentMethod         string               `json:"defaultPaymentMethod,omitempty"`
+	ID                           StoreID              `json:"id,omitempty"`
+}
+
+type UserID string
+
+type UserResponse struct {
+	ID                        UserID   `json:"id"`
+	Email                     string   `json:"email"`
+	EmailConfirmed            bool     `json:"emailConfirmed"`
+	RequiresEmailConfirmation bool     `json:"requiresEmailConfirmation"`
+	Created                   int64    `json:"created,omitempty"`
+	Roles                     []string `json:"roles"`
+}
+
+type UserRequest struct {
+	Email           string `json:"email"`
+	Password        string `json:"password"`
+	IsAdministrator bool   `json:"isAdministrator"`
+}

--- a/examples/main.go
+++ b/examples/main.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/jon4hz/go-btcpay"
 	"github.com/jon4hz/go-btcpay/examples/config"
@@ -21,26 +20,31 @@ func main() {
 	}
 
 	client := btcpay.NewBasicClient(config.BTCPay.URL, config.BTCPay.Username, config.BTCPay.Password)
-	/* cont, cancel := context.WithTimeout(ctx, 1)
+
+	/* cont, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 	fmt.Println(client.GetHealth(cont)) */
+
+	//createAndDeleteCurrentAPIKey(client)
+
 	fmt.Println(client.GetServerInfo(ctx))
 
 	// get store id
 
-	/* stores, _, err := client.GetStores(ctx)
+	/* stores, code, err := client.GetStores(ctx)
 	if err != nil {
+		fmt.Println(code)
 		panic(err)
 	}
-	storeID := getStoreID(stores)
-	createInvoiceByStoreGetAndDeleteInvoiceByID(client, storeID) */
+	storeID := getStoreID(stores) */
+	//createInvoiceByStoreGetAndDeleteInvoiceByID(client, storeID)
 
 	//getInvoicesByStore(client, storeID)
-	//reateAndDeleteInvoice(client, storeID)
+	//createAndDeleteInvoice(client, storeID)
 
 	//createNewStore(client)
 
-	//createNewUser(client)
+	createNewUser(client)
 	//fmt.Println(client.GetUser(ctx))
 
 	/* fmt.Println((&btcpay.Client{URL: client.URL}).GetLanguageCodes(ctx))
@@ -61,7 +65,7 @@ func main() {
 	//getAndDeleteNotification(client)
 }
 
-func getAndDeleteNotification(c *btcpay.Client) {
+/* func getAndDeleteNotification(c *btcpay.Client) {
 	notifications, _, err := c.GetNotifications(ctx)
 	if err != nil {
 		panic(err)
@@ -124,7 +128,7 @@ func createPrintPageDeleteInvoice(c *btcpay.Client, storeID *btcpay.StoreID) {
 	invoiceC.ID = invoice.ID
 	fmt.Println(invoiceC.ArchiveInvoice(ctx))
 }
-
+*/
 func createNewUser(c *btcpay.Client) {
 	fmt.Println(c.CreateUser(ctx, &btcpay.UserRequest{
 		Email:           "test@test.com",
@@ -137,6 +141,7 @@ func createNewStore(c *btcpay.Client) {
 	fmt.Println(c.CreateStore(ctx, &btcpay.StoreRequest{Name: "test03"}))
 }
 
+/*
 func createInvoiceByStoreGetAndDeleteInvoiceByID(client *btcpay.Client, storeID btcpay.StoreID) {
 	// create a new storeClient
 	storeClient := client.Store
@@ -164,7 +169,7 @@ func getInvoicesByStore(client *btcpay.Client, storeID btcpay.StoreID) {
 	storeClient.ID = storeID
 	fmt.Println(storeClient.GetInvoices(ctx))
 }
-
+*/
 func getStoreID(stores []*btcpay.StoreResponse) btcpay.StoreID {
 	for _, v := range stores {
 		if v.Name == "test01" {
@@ -176,8 +181,9 @@ func getStoreID(stores []*btcpay.StoreResponse) btcpay.StoreID {
 
 func createAndDeleteInvoice(client *btcpay.Client, storeID btcpay.StoreID) {
 	fmt.Println(storeID)
-	invoice, _, err := client.CreateInvoice(ctx, &storeID, &btcpay.InvoiceRequest{Amount: "11", Currency: "USD", Metadata: btcpay.InvoiceMetadata{"test": "asdf", "test2": "aaaa"}})
+	invoice, code, err := client.CreateInvoice(ctx, &storeID, &btcpay.InvoiceRequest{Amount: "11", Currency: "USD", Metadata: btcpay.InvoiceMetadata{"test": "asdf", "test2": "aaaa"}})
 	if err != nil {
+		fmt.Println(code)
 		panic(err)
 	}
 	fmt.Println(invoice)
@@ -203,15 +209,14 @@ func createAndDeleteAPIKey(client *btcpay.Client) {
 
 func createAndDeleteCurrentAPIKey(client *btcpay.Client) {
 	// create new APIKey
-	apiKey, _, err := client.CreateAPIKey(ctx, &btcpay.APIKeyRequest{
+	apiKey, statusCode, err := client.CreateAPIKey(ctx, &btcpay.APIKeyRequest{
 		Permissions: []btcpay.BTCPayPermission{btcpay.CreateCustomPermission(btcpay.GetPermission().StoreCanviewinvoices, btcpay.StoreID("66tU3WhCAcsbocA3EmUXHE96XsoVQjWMUiTp3s6LLYAn"))}})
 	if err != nil {
-		panic(err)
+		log.Fatal(statusCode, err)
 	}
 
 	// add APIKey to client
 	client.APIKey = apiKey.APIKey
 	fmt.Println(client.GetCurrentAPIKey(ctx))
-	time.Sleep(10 * time.Second)
 	client.RevokeCurrentAPIKey(ctx)
 }

--- a/health.go
+++ b/health.go
@@ -2,29 +2,15 @@ package btcpay
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
-
-type HealthResponse struct {
-	Synchronized bool `json:"synchronized"`
-}
 
 func (c *Client) GetHealth(ctx context.Context) (*HealthResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/health", c.URL)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes HealthResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes HealthResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }

--- a/invoices.go
+++ b/invoices.go
@@ -1,211 +1,48 @@
 package btcpay
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
-
-type InvoiceID string
-
-type Invoice struct {
-	Store  *Store
-	Client *Client
-	ID     InvoiceID
-}
-
-type InvoiceResponse struct {
-	Amount           string                        `json:"amount,omitempty"`
-	Currency         string                        `json:"currency,omitempty"`
-	Metadata         InvoiceMetadata               `json:"metadata,omitempty"`
-	Checkout         InvoiceCheckout               `json:"checkout,omitempty"`
-	ID               InvoiceID                     `json:"id"`
-	CheckoutLink     string                        `json:"checkoutLink"`
-	CreatedTime      int64                         `json:"createdTime"`
-	ExpirationTime   int64                         `json:"expirationTime"`
-	MonitoringTime   int64                         `json:"monitoringTime"`
-	Status           BTCPayInvoiceStatus           `json:"status"`
-	AdditionalStatus BTCPayInvoiceAdditionalStatus `json:"additionalStatus"`
-}
-
-type InvoiceMetadata map[string]interface{}
-
-// Enums SpeedPolicy
-type BTCPaySpeedPolicy string
-
-type SpeedPolicy struct {
-	HighSpeed      BTCPaySpeedPolicy
-	MediumSpeed    BTCPaySpeedPolicy
-	LowMediumSpeed BTCPaySpeedPolicy
-	LowSpeed       BTCPaySpeedPolicy
-}
-
-func GetSpeedPolicy() *SpeedPolicy {
-	return &SpeedPolicy{
-		HighSpeed:      "HighSpeed",
-		MediumSpeed:    "MediumSpeed",
-		LowMediumSpeed: "LowMediumSpeed",
-		LowSpeed:       "LowSpeed",
-	}
-}
-
-// Enums InvoiceStatus
-type BTCPayInvoiceStatus string
-
-type InvoiceStatus struct {
-	New        BTCPayInvoiceStatus
-	Processing BTCPayInvoiceStatus
-	Expired    BTCPayInvoiceStatus
-	Invalid    BTCPayInvoiceStatus
-	Settled    BTCPayInvoiceStatus
-}
-
-func GetInvoiceStatus() *InvoiceStatus {
-	return &InvoiceStatus{
-		New:        "New",
-		Processing: "Processing",
-		Expired:    "Expired",
-		Invalid:    "Invalid",
-		Settled:    "Settled",
-	}
-}
-
-// Enums InvoiceAdditionalStatus
-type BTCPayInvoiceAdditionalStatus string
-
-type InvoiceAdditionalStatus struct {
-	None        BTCPayInvoiceAdditionalStatus
-	PaidLate    BTCPayInvoiceAdditionalStatus
-	PaidPartial BTCPayInvoiceAdditionalStatus
-	Marked      BTCPayInvoiceAdditionalStatus
-	AddInvalid  BTCPayInvoiceAdditionalStatus
-	PaidOver    BTCPayInvoiceAdditionalStatus
-}
-
-func GetInvoiceAdditionalStatus() *InvoiceAdditionalStatus {
-	return &InvoiceAdditionalStatus{
-		None:        "None",
-		PaidLate:    "PaidLate",
-		PaidPartial: "PaidPartial",
-		Marked:      "Marked",
-		AddInvalid:  "Invalid",
-		PaidOver:    "PaidOver",
-	}
-
-}
-
-// Enums InvoiceStatusMark
-type BTCPayInvoiceStatusMark string
-
-type InvoiceStatusMark struct {
-	MarkInvalid  BTCPayInvoiceStatusMark
-	MarkComplete BTCPayInvoiceStatusMark
-}
-
-func GetInvoiceStatusMark() *InvoiceStatusMark {
-	return &InvoiceStatusMark{
-		MarkInvalid:  "Invalid",
-		MarkComplete: "Complete",
-	}
-}
-
-type InvoiceCheckout struct {
-	SpeedPolicy       BTCPaySpeedPolicy `json:"speedPolicy,omitempty"`
-	PaymentMethods    []string          `json:"paymentMethods,omitempty"`
-	ExpirationMinutes int               `json:"expirationMinutes,omitempty"`
-	MonitoringMinutes int               `json:"monitoringMinutes,omitempty"`
-	PaymentTolerance  float64           `json:"paymentTolerance,omitempty"`
-	RedirectURL       string            `json:"redirectURL,omitempty"`
-	DefaultLanguage   string            `json:"defaultLanguage,omitempty"`
-}
 
 // Get an array of all Invoices from a single store.
 func (c *Client) GetInvoices(ctx context.Context, storeID *StoreID) ([]*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices", c.URL, *storeID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes []*InvoiceResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes []*InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return dataRes, statusCode, nil
 }
 
 func (s *Store) GetInvoices(ctx context.Context) ([]*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices", s.Client.URL, s.ID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes []*InvoiceResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
 	}
-	var dataRes []*InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
-	}
 	return dataRes, statusCode, nil
-}
-
-type InvoiceRequest struct {
-	Amount          string          `json:"amount"`
-	Currency        string          `json:"currency,omitempty"`
-	Metadata        InvoiceMetadata `json:"metadata,omitempty"`
-	InvoiceCheckout InvoiceCheckout `json:"checkout,omitempty"`
 }
 
 // Create an invoice for a certain store
 func (c *Client) CreateInvoice(ctx context.Context, storeID *StoreID, invoiceRequest *InvoiceRequest) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices", c.URL, *storeID)
-	dataReq, err := json.Marshal(invoiceRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "POST", &dataRes, invoiceRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (s *Store) CreateInvoice(ctx context.Context, invoiceRequest *InvoiceRequest) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices", s.Client.URL, s.ID)
-	dataReq, err := json.Marshal(invoiceRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "POST", &dataRes, invoiceRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
@@ -213,54 +50,30 @@ func (s *Store) CreateInvoice(ctx context.Context, invoiceRequest *InvoiceReques
 // Get a signle invoice from a single store.
 func (c *Client) GetInvoice(ctx context.Context, storeID *StoreID, invoiceID *InvoiceID) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s", c.URL, *storeID, *invoiceID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (s *Store) GetInvoice(ctx context.Context, invoiceID *InvoiceID) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s", s.Client.URL, s.ID, *invoiceID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (i *Invoice) GetInvoice(ctx context.Context) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s", i.Client.URL, i.Store.ID, i.ID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := i.Client.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := i.Client.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
@@ -268,11 +81,7 @@ func (i *Invoice) GetInvoice(ctx context.Context) (*InvoiceResponse, int, error)
 // Archive a single invoice of a store
 func (c *Client) ArchiveInvoice(ctx context.Context, storeID *StoreID, invoiceID *InvoiceID) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s", c.URL, *storeID, *invoiceID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := c.doRequest(req)
+	statusCode, err := c.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
@@ -281,11 +90,7 @@ func (c *Client) ArchiveInvoice(ctx context.Context, storeID *StoreID, invoiceID
 
 func (s *Store) ArchiveInvoice(ctx context.Context, invoiceID *InvoiceID) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s", s.Client.URL, s.ID, *invoiceID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := s.Client.doRequest(req)
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
@@ -294,253 +99,102 @@ func (s *Store) ArchiveInvoice(ctx context.Context, invoiceID *InvoiceID) (int, 
 
 func (i *Invoice) ArchiveInvoice(ctx context.Context) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s", i.Client.URL, i.Store.ID, i.ID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := i.Client.doRequest(req)
+	statusCode, err := i.Client.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
 	return statusCode, nil
 }
 
-type InvoiceUpdate struct {
-	Metadata InvoiceMetadata `json:"metadata,omitempty"`
-}
-
 // Update the metadata from an existing invoice
 func (c *Client) UpdateInvoice(ctx context.Context, storeID *StoreID, invoiceID *InvoiceID, invoiceUpdate *InvoiceUpdate) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s", c.URL, *storeID, *invoiceID)
-	dataReq, err := json.Marshal(invoiceUpdate)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "PUT", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "PUT", &dataRes, invoiceUpdate)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (s *Store) UpdateInvoice(ctx context.Context, invoiceID *InvoiceID, invoiceUpdate *InvoiceUpdate) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s", s.Client.URL, s.ID, *invoiceID)
-	dataReq, err := json.Marshal(invoiceUpdate)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "PUT", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "PUT", &dataRes, invoiceUpdate)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (i *Invoice) UpdateInvoice(ctx context.Context, invoiceUpdate *InvoiceUpdate) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s", i.Client.URL, i.Store.ID, i.ID)
-	dataReq, err := json.Marshal(invoiceUpdate)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "PUT", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := i.Client.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := i.Client.doRequest(ctx, endpoint, "PUT", &dataRes, invoiceUpdate)
 	if err != nil {
 		return nil, statusCode, err
 	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
-	}
 	return &dataRes, statusCode, nil
-}
-
-// Enums PaymentStatus
-type BTCPayPaymentStatus string
-
-type PaymentStatus struct {
-	New        BTCPayPaymentStatus
-	Processing BTCPayPaymentStatus
-	Expired    BTCPayPaymentStatus
-	Invalid    BTCPayPaymentStatus
-	Settled    BTCPayPaymentStatus
-}
-
-func GetPaymentStatus() *PaymentStatus {
-	return &PaymentStatus{
-		Processing: "Processing",
-		Invalid:    "Invalid",
-		Settled:    "Settled",
-	}
-}
-
-type PaymentID string
-
-type Payment struct {
-	ID           PaymentID           `json:"id"`
-	ReceivedDate int64               `json:"receivedDate"`
-	Value        string              `json:"value"`
-	Fee          string              `json:"fee"`
-	Status       BTCPayPaymentStatus `json:"status"`
-	Destination  string              `json:"destination"`
-}
-
-type InvoicePaymentMethodResponse struct {
-	PaymentMethod     string    `json:"paymentMethod"`
-	Destination       string    `json:"destination"`
-	PaymentLink       string    `json:"paymentLink,omitempty"`
-	Rate              string    `json:"rate"`
-	PaymentMethodPaid string    `json:"paymentMethodPaid"`
-	TotalPaid         string    `json:"totalPaid"`
-	Due               string    `json:"due"`
-	Amount            string    `json:"amount"`
-	NetworkFee        string    `json:"networkFee"`
-	Payments          []Payment `json:"payments"`
 }
 
 // View information about the specified invoice's payment methods
 func (c *Client) GetInvoicePaymentMethod(ctx context.Context, storeID *StoreID, invoiceID *InvoiceID) ([]*InvoicePaymentMethodResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s/payment-methods", c.URL, *storeID, *invoiceID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes []*InvoicePaymentMethodResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes []*InvoicePaymentMethodResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return dataRes, statusCode, nil
 }
 
 func (s *Store) GetInvoicePaymentMethod(ctx context.Context, invoiceID *InvoiceID) ([]*InvoicePaymentMethodResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s/payment-methods", s.Client.URL, s.ID, *invoiceID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes []*InvoicePaymentMethodResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes []*InvoicePaymentMethodResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return dataRes, statusCode, nil
 }
 
 func (i *Invoice) GetInvoicePaymentMethod(ctx context.Context) ([]*InvoicePaymentMethodResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s/payment-methods", i.Client.URL, i.Store.ID, i.ID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := i.Client.doRequest(req)
+	var dataRes []*InvoicePaymentMethodResponse
+	statusCode, err := i.Client.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
 	}
-	var dataRes []*InvoicePaymentMethodResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
-	}
 	return dataRes, statusCode, nil
-}
-
-type MarkInvoiceStatusRequest struct {
-	Status BTCPayInvoiceStatusMark `json:"status"`
 }
 
 // Mark an invoice as invalid or settled.
 func (c *Client) MarkInvoiceStatus(ctx context.Context, storeID *StoreID, invoiceID *InvoiceID, markInvoiceStatusRequest *MarkInvoiceStatusRequest) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s/status", c.URL, *storeID, *invoiceID)
-	dataReq, err := json.Marshal(markInvoiceStatusRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "POST", &dataRes, markInvoiceStatusRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (s *Store) MarkInvoiceStatus(ctx context.Context, invoiceID *InvoiceID, markInvoiceStatusRequest *MarkInvoiceStatusRequest) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s/status", s.Client.URL, s.ID, *invoiceID)
-	dataReq, err := json.Marshal(markInvoiceStatusRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "POST", &dataRes, markInvoiceStatusRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (i *Invoice) MarkInvoiceStatus(ctx context.Context, markInvoiceStatusRequest *MarkInvoiceStatusRequest) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s/status", i.Client.URL, i.Store.ID, i.ID)
-	dataReq, err := json.Marshal(markInvoiceStatusRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := i.Client.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := i.Client.doRequest(ctx, endpoint, "POST", &dataRes, markInvoiceStatusRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
@@ -548,54 +202,30 @@ func (i *Invoice) MarkInvoiceStatus(ctx context.Context, markInvoiceStatusReques
 // unarchive an invoice
 func (c *Client) UnarchiveInvoice(ctx context.Context, storeID *StoreID, invoiceID *InvoiceID) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s/unarchive", c.URL, *storeID, *invoiceID)
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "POST", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (s *Store) UnarchiveInvoice(ctx context.Context, invoiceID *InvoiceID) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s/unarchive", s.Client.URL, s.ID, *invoiceID)
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "POST", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (i *Invoice) UnarchiveInvoice(ctx context.Context) (*InvoiceResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/invoices/%s/unarchive", i.Client.URL, i.Store.ID, i.ID)
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := i.Client.doRequest(req)
+	var dataRes InvoiceResponse
+	statusCode, err := i.Client.doRequest(ctx, endpoint, "POST", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes InvoiceResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }

--- a/misc.go
+++ b/misc.go
@@ -2,37 +2,18 @@ package btcpay
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 )
 
-type LanguageCodesRespose struct {
-	Code            string `json:"code"`
-	CurrentLanguage string `json:"currentLanguage"`
-}
-
-// Bug
 func (c *Client) GetLanguageCodes(ctx context.Context) ([]*LanguageCodesRespose, int, error) {
 	endpoint := fmt.Sprintf("%s/misc/lang", c.URL)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes []*LanguageCodesRespose
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
 	}
-	var dataRes []*LanguageCodesRespose
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
-	}
 	return dataRes, statusCode, nil
-}
-
-type InvoiceCheckoutPage struct {
-	Page []byte
 }
 
 // View the checkout page of an invoice
@@ -48,7 +29,7 @@ func (c *Client) GetInvoiceCheckoutPage(ctx context.Context, invoiceID *InvoiceI
 	if err != nil {
 		return nil, 0, err
 	}
-	bytes, statusCode, err := c.doRequest(req)
+	bytes, statusCode, err := c.doSimpleRequest(req)
 	if err != nil {
 		return nil, statusCode, err
 	}
@@ -65,7 +46,7 @@ func (i *Invoice) GetInvoiceCheckoutPage(ctx context.Context) (*InvoiceCheckoutP
 	if err != nil {
 		return nil, 0, err
 	}
-	bytes, statusCode, err := i.Client.doRequest(req)
+	bytes, statusCode, err := i.Client.doSimpleRequest(req)
 	if err != nil {
 		return nil, statusCode, err
 	}

--- a/payment_request.go
+++ b/payment_request.go
@@ -1,91 +1,27 @@
 package btcpay
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
-
-type PaymentRequestID string
-
-type PaymentRequest struct {
-	Store  *Store
-	Client *Client
-	ID     PaymentRequestID
-}
-
-// Enums PaymentRequestStatus
-type BTCPayPaymentRequestStatus string
-
-type PaymentRequestStatus struct {
-	Pending   BTCPayInvoiceStatus
-	Completed BTCPayInvoiceStatus
-	Expired   BTCPayInvoiceStatus
-}
-
-func GetPaymentRequestStatus() *PaymentRequestStatus {
-	return &PaymentRequestStatus{
-		Pending:   "Pending",
-		Completed: "Completed",
-		Expired:   "Expired",
-	}
-}
-
-type PaymentRequestRequest struct {
-	Amount                    float64 `json:"amount"`
-	Title                     string  `json:"title"`
-	Currency                  string  `json:"currency"`
-	Email                     string  `json:"email,omitempty"`
-	Description               string  `json:"description,omitempty"`
-	ExpiryDate                int64   `json:"expiryDate,omitempty"`
-	EmbeddedCSS               string  `json:"embeddedCSS,omitempty"`
-	CustomCSSLink             string  `json:"customCSSLink,omitempty"`
-	AllowCustomPaymentAmounts bool    `json:"allowCustomPaymentAmounts,omitempty"`
-}
-
-type PaymentRequestResponse struct {
-	ID       PaymentRequestID           `json:"id"`
-	Status   BTCPayPaymentRequestStatus `json:"status"`
-	Created  string                     `json:"created"`
-	Archived bool                       `json:"archived"`
-	PaymentRequestRequest
-}
 
 // View information about the existing payment requests
 func (c *Client) GetPaymentRequests(ctx context.Context, storeID *StoreID) ([]*PaymentRequestResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests", c.URL, *storeID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes []*PaymentRequestResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes []*PaymentRequestResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return dataRes, statusCode, nil
 }
 
 func (s *Store) GetPaymentRequests(ctx context.Context) ([]*PaymentRequestResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests", s.Client.URL, s.ID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes []*PaymentRequestResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes []*PaymentRequestResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return dataRes, statusCode, nil
 }
@@ -93,99 +29,51 @@ func (s *Store) GetPaymentRequests(ctx context.Context) ([]*PaymentRequestRespon
 // Create a new payment request
 func (c *Client) CreatePaymentRequest(ctx context.Context, storeID *StoreID, paymentRequestRequest *PaymentRequestRequest) (*PaymentRequestResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests", c.URL, *storeID)
-	dataReq, err := json.Marshal(paymentRequestRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes PaymentRequestResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "POST", &dataRes, paymentRequestRequest)
 	if err != nil {
 		return nil, statusCode, err
 	}
-	var dataRes *PaymentRequestResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
-	}
-	return dataRes, statusCode, nil
+	return &dataRes, statusCode, nil
 }
 
 func (s *Store) CreatePaymentRequest(ctx context.Context, paymentRequestRequest *PaymentRequestRequest) (*PaymentRequestResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests", s.Client.URL, s.ID)
-	dataReq, err := json.Marshal(paymentRequestRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes PaymentRequestResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "POST", &dataRes, paymentRequestRequest)
 	if err != nil {
 		return nil, statusCode, err
 	}
-	var dataRes *PaymentRequestResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
-	}
-	return dataRes, statusCode, nil
+	return &dataRes, statusCode, nil
 }
 
 // View information about the specified payment request
 func (c *Client) GetPaymentRequest(ctx context.Context, storeID *StoreID, paymentRequestID *PaymentRequestID) (*PaymentRequestResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests/%s", c.URL, *storeID, *paymentRequestID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes PaymentRequestResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PaymentRequestResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (s *Store) GetPaymentRequest(ctx context.Context, paymentRequestID *PaymentRequestID) (*PaymentRequestResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests/%s", s.Client.URL, s.ID, *paymentRequestID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes PaymentRequestResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PaymentRequestResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (p *PaymentRequest) GetPaymentRequest(ctx context.Context) (*PaymentRequestResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests/%s", p.Client.URL, p.Store.ID, p.ID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := p.Client.doRequest(req)
+	var dataRes PaymentRequestResponse
+	statusCode, err := p.Client.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PaymentRequestResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
@@ -193,11 +81,7 @@ func (p *PaymentRequest) GetPaymentRequest(ctx context.Context) (*PaymentRequest
 // Archives the specified payment request.
 func (c *Client) ArchivePaymentRequest(ctx context.Context, storeID *StoreID, paymentRequestID *PaymentRequestID) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests/%s", c.URL, *storeID, *paymentRequestID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := c.doRequest(req)
+	statusCode, err := c.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
@@ -206,11 +90,7 @@ func (c *Client) ArchivePaymentRequest(ctx context.Context, storeID *StoreID, pa
 
 func (s *Store) ArchivePaymentRequest(ctx context.Context, paymentRequestID *PaymentRequestID) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests/%s", s.Client.URL, s.ID, *paymentRequestID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := s.Client.doRequest(req)
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
@@ -219,11 +99,7 @@ func (s *Store) ArchivePaymentRequest(ctx context.Context, paymentRequestID *Pay
 
 func (p *PaymentRequest) ArchivePaymentRequest(ctx context.Context) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests/%s", p.Client.URL, p.Store.ID, p.ID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := p.Client.doRequest(req)
+	statusCode, err := p.Client.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
@@ -233,66 +109,30 @@ func (p *PaymentRequest) ArchivePaymentRequest(ctx context.Context) (int, error)
 // Update a payment request
 func (c *Client) UpdatePaymentRequest(ctx context.Context, storeID *StoreID, paymentRequestID *PaymentRequestID, paymentRequestUpdate *PaymentRequestRequest) (*PaymentRequestResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests/%s", c.URL, *storeID, *paymentRequestID)
-	dataReq, err := json.Marshal(paymentRequestUpdate)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "PUT", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes PaymentRequestResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "PUT", &dataRes, paymentRequestUpdate)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PaymentRequestResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (s *Store) UpdatePaymentRequest(ctx context.Context, paymentRequestID *PaymentRequestID, paymentRequestUpdate *PaymentRequestRequest) (*PaymentRequestResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests/%s", s.Client.URL, s.ID, *paymentRequestID)
-	dataReq, err := json.Marshal(paymentRequestUpdate)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "PUT", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes PaymentRequestResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "PUT", &dataRes, paymentRequestUpdate)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PaymentRequestResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (p *PaymentRequest) UpdatePaymentRequest(ctx context.Context, paymentRequestUpdate *PaymentRequestRequest) (*PaymentRequestResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payment-requests/%s", p.Client.URL, p.Store.ID, p.ID)
-	dataReq, err := json.Marshal(paymentRequestUpdate)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "PUT", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := p.Client.doRequest(req)
+	var dataRes PaymentRequestResponse
+	statusCode, err := p.Client.doRequest(ctx, endpoint, "PUT", &dataRes, paymentRequestUpdate)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PaymentRequestResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }

--- a/pull_payments.go
+++ b/pull_payments.go
@@ -1,30 +1,9 @@
 package btcpay
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
-
-type PullPaymentID string
-
-type PullPayment struct {
-	Store  *Store
-	Client *Client
-	ID     PullPaymentID
-}
-
-type PullPaymentResponse struct {
-	ID       PullPaymentID `json:"id"`
-	Name     string        `json:"name"`
-	Currency string        `json:"currency"`
-	Amount   string        `json:"amount"`
-	Period   int64         `json:"period,omitempty"`
-	Archived bool          `json:"archived"`
-	ViewLink string        `json:"viewLink"`
-}
 
 // Get the pull payments of a store
 func (c *Client) GetPullPayments(ctx context.Context, storeID *StoreID, includeArchived ...bool) ([]*PullPaymentResponse, int, error) {
@@ -34,18 +13,10 @@ func (c *Client) GetPullPayments(ctx context.Context, storeID *StoreID, includeA
 	} else {
 		endpoint = fmt.Sprintf("%s/api/v1/stores/%s/pull-payments", c.URL, *storeID)
 	}
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes []*PullPaymentResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes []*PullPaymentResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return dataRes, statusCode, nil
 }
@@ -57,83 +28,37 @@ func (s *Store) GetPullPayments(ctx context.Context, includeArchived ...bool) ([
 	} else {
 		endpoint = fmt.Sprintf("%s/api/v1/stores/%s/pull-payments", s.Client.URL, s.ID)
 	}
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes []*PullPaymentResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes []*PullPaymentResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return dataRes, statusCode, nil
 }
 
-type PullPaymentRequest struct {
-	Name           string   `json:"name,omitempty"`
-	Amount         string   `json:"amount"`
-	Currency       string   `json:"currency"`
-	Period         int64    `json:"period,omitempty"`
-	StartsAt       int64    `json:"startsAt,omitempty"`
-	ExpiresAt      int64    `json:"expiresAt,omitempty"`
-	PaymentMethods []string `json:"paymentMethods"`
-}
-
 func (c *Client) CreatePullPayment(ctx context.Context, storeID *StoreID, pullPaymentRequest *PullPaymentRequest) (*PullPaymentResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/pull-payments", c.URL, *storeID)
-	dataReq, err := json.Marshal(pullPaymentRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes PullPaymentResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "POST", &dataRes, pullPaymentRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PullPaymentResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (s *Store) CreatePullPayment(ctx context.Context, pullPaymentRequest *PullPaymentRequest) (*PullPaymentResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/pull-payments", s.Client.URL, s.ID)
-	dataReq, err := json.Marshal(pullPaymentRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes PullPaymentResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "POST", &dataRes, pullPaymentRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PullPaymentResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (c *Client) ArchivePullPayment(ctx context.Context, storeID *StoreID, pullPaymentID *PullPaymentID) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/pull-payments/%s", c.URL, *storeID, *pullPaymentID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := c.doRequest(req)
+	statusCode, err := c.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
@@ -142,11 +67,7 @@ func (c *Client) ArchivePullPayment(ctx context.Context, storeID *StoreID, pullP
 
 func (s *Store) ArchivePullPayment(ctx context.Context, pullPaymentID *PullPaymentID) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/pull-payments/%s", s.Client.URL, s.ID, *pullPaymentID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := s.Client.doRequest(req)
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
@@ -155,126 +76,40 @@ func (s *Store) ArchivePullPayment(ctx context.Context, pullPaymentID *PullPayme
 
 func (p *PullPayment) ArchivePullPayment(ctx context.Context) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/pull-payments/%s", p.Client.URL, p.Store.ID, p.ID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := p.Client.doRequest(req)
+	statusCode, err := p.Client.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
 	return statusCode, nil
 }
 
-// Enums NetworkFeeMode
-type BTCPayPayoutStatus string
-
-type PayoutStatus struct {
-	AwaitingApproval BTCPayPayoutStatus
-	AwaitingPayment  BTCPayPayoutStatus
-	InProgress       BTCPayPayoutStatus
-	Completed        BTCPayPayoutStatus
-	Cancelled        BTCPayPayoutStatus
-}
-
-func GetPayoutStatus() *PayoutStatus {
-	return &PayoutStatus{
-		AwaitingApproval: "AwaitingApproval",
-		AwaitingPayment:  "AwaitingPayment",
-		InProgress:       "InProgress",
-		Completed:        "Completed",
-		Cancelled:        "Cancelled",
-	}
-}
-
-type PayoutID string
-
-type Payout struct {
-	Store  *Store
-	Client *Client
-	ID     PayoutID
-}
-
-type PayoutResponse struct {
-	ID                  PayoutID           `json:"id"`
-	Revision            int64              `json:"revision"`
-	PullPaymentID       PullPaymentID      `json:"pullPaymentId"`
-	Date                string             `json:"date"`
-	Destination         string             `json:"destination"`
-	Amount              string             `json:"amount"`
-	PaymentMethod       string             `json:"paymentMethod"`
-	PaymentMethodAmount string             `json:"paymentMethodAmount"`
-	State               BTCPayPayoutStatus `json:"state"`
-}
-
-type PayoutApproveRequest struct {
-	Revision int64  `json:"revision"`
-	RateRule string `json:"rateRule,omitempty"`
-}
-
 // Approve a payout
-func (c *Client) ApprovePayout(ctx context.Context, storeID *StoreID, payoutID *PayoutID, PayoutApproveRequest *PayoutApproveRequest) (*PayoutResponse, int, error) {
+func (c *Client) ApprovePayout(ctx context.Context, storeID *StoreID, payoutID *PayoutID, payoutApproveRequest *PayoutApproveRequest) (*PayoutResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payouts/%s", c.URL, *storeID, *payoutID)
-	dataReq, err := json.Marshal(PayoutApproveRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes PayoutResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "POST", &dataRes, payoutApproveRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PayoutResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
-func (s *Store) ApprovePayout(ctx context.Context, payoutID *PayoutID, PayoutApproveRequest *PayoutApproveRequest) (*PayoutResponse, int, error) {
+func (s *Store) ApprovePayout(ctx context.Context, payoutID *PayoutID, payoutApproveRequest *PayoutApproveRequest) (*PayoutResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payouts/%s", s.Client.URL, s.ID, *payoutID)
-	dataReq, err := json.Marshal(PayoutApproveRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes PayoutResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "POST", &dataRes, payoutApproveRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PayoutResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
-func (p *Payout) ApprovePayout(ctx context.Context, PayoutApproveRequest *PayoutApproveRequest) (*PayoutResponse, int, error) {
+func (p *Payout) ApprovePayout(ctx context.Context, payoutApproveRequest *PayoutApproveRequest) (*PayoutResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payouts/%s", p.Client.URL, p.Store.ID, p.ID)
-	dataReq, err := json.Marshal(PayoutApproveRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := p.Client.doRequest(req)
+	var dataRes PayoutResponse
+	statusCode, err := p.Client.doRequest(ctx, endpoint, "POST", &dataRes, payoutApproveRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PayoutResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
@@ -282,11 +117,7 @@ func (p *Payout) ApprovePayout(ctx context.Context, PayoutApproveRequest *Payout
 // Cancel the payout
 func (c *Client) CancelPayout(ctx context.Context, storeID *StoreID, payoutID *PayoutID) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payouts/%s", c.URL, *storeID, *payoutID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := c.doRequest(req)
+	statusCode, err := c.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
@@ -295,11 +126,7 @@ func (c *Client) CancelPayout(ctx context.Context, storeID *StoreID, payoutID *P
 
 func (s *Store) CancelPayout(ctx context.Context, payoutID *PayoutID) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payouts/%s", s.Client.URL, s.ID, *payoutID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := s.Client.doRequest(req)
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
@@ -308,11 +135,7 @@ func (s *Store) CancelPayout(ctx context.Context, payoutID *PayoutID) (int, erro
 
 func (p *Payout) CancelPayout(ctx context.Context) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s/payouts/%s", p.Client.URL, p.Store.ID, p.ID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := p.Client.doRequest(req)
+	statusCode, err := p.Client.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
@@ -322,36 +145,20 @@ func (p *Payout) CancelPayout(ctx context.Context) (int, error) {
 // Get a pull payment
 func (c *Client) GetPullPayment(ctx context.Context, pullPaymentID *PullPaymentID) (*PullPaymentResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/pull-payments/%s", c.URL, *pullPaymentID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes PullPaymentResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PullPaymentResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (p *PullPayment) GetPullPayment(ctx context.Context) (*PullPaymentResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/pull-payments/%s", p.Client.URL, p.ID)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := p.Client.doRequest(req)
+	var dataRes PullPaymentResponse
+	statusCode, err := p.Client.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PullPaymentResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
@@ -364,18 +171,10 @@ func (c *Client) GetPayouts(ctx context.Context, pullPaymentID *PullPaymentID, i
 	} else {
 		endpoint = fmt.Sprintf("%s/api/v1/pull-payments/%s/payouts", c.URL, *pullPaymentID)
 	}
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes []*PayoutResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes []*PayoutResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return dataRes, statusCode, nil
 }
@@ -387,69 +186,31 @@ func (p *PullPayment) GetPayouts(ctx context.Context, includeCancelled ...bool) 
 	} else {
 		endpoint = fmt.Sprintf("%s/api/v1/pull-payments/%s/payouts", p.Client.URL, p.ID)
 	}
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := p.Client.doRequest(req)
+	var dataRes []*PayoutResponse
+	statusCode, err := p.Client.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
 	}
-	var dataRes []*PayoutResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
-	}
 	return dataRes, statusCode, nil
-}
-
-type PayoutRequest struct {
-	Destination   string `json:"destination"`
-	Amount        string `json:"amount"`
-	PaymentMethod string `json:"paymentMethod"`
 }
 
 // create a new payout
 func (c *Client) CreatePayout(ctx context.Context, pullPaymentID *PullPaymentID, payoutRequest *PayoutRequest) (*PayoutResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/pull-payments/%s/payouts", c.URL, *pullPaymentID)
-	dataReq, err := json.Marshal(payoutRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes PayoutResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "POST", &dataRes, payoutRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PayoutResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (p *PullPayment) CreatePayout(ctx context.Context, payoutRequest *PayoutRequest) (*PayoutResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/pull-payments/%s/payouts", p.Client.URL, p.ID)
-	dataReq, err := json.Marshal(payoutRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := p.Client.doRequest(req)
+	var dataRes PayoutResponse
+	statusCode, err := p.Client.doRequest(ctx, endpoint, "POST", &dataRes, payoutRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes PayoutResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }

--- a/server_info.go
+++ b/server_info.go
@@ -2,46 +2,15 @@ package btcpay
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
-
-type ServerInfoResponse struct {
-	Version                 string             `json:"version"`
-	Onion                   string             `json:"onion"`
-	SupportedPaymentMethods []string           `json:"supportedPaymentMethods"`
-	FullySynched            bool               `json:"fullySynched"`
-	SyncStatus              []ServerSyncStatus `json:"syncStatus"`
-}
-
-type ServerSyncStatus struct {
-	CryptoCode      string                `json:"cryptoCode"`
-	NodeInformation ServerNodeInformation `json:"nodeInformation,omitempty"`
-	ChainHeight     int64                 `json:"chainHeight"`
-	SyncHeight      int64                 `json:"syncHeight,omitempty"`
-}
-
-type ServerNodeInformation struct {
-	Headers              int64   `json:"headers"`
-	Blocks               int64   `json:"blocks"`
-	VerificationProgress float64 `json:"verificationProgress"`
-}
 
 func (c *Client) GetServerInfo(ctx context.Context) (*ServerInfoResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/server/info", c.URL)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes ServerInfoResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes ServerInfoResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }

--- a/stores.go
+++ b/stores.go
@@ -1,126 +1,28 @@
 package btcpay
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
-
-type StoreID string
-
-type Store struct {
-	ID     StoreID
-	Client *Client
-}
-
-// Enums NetworkFeeMode
-type BTCPayNetworkFeeMode string
-
-type NetworkFeeMode struct {
-	MultiplePaymentsOnly BTCPayNetworkFeeMode
-	Always               BTCPayNetworkFeeMode
-	Never                BTCPayNetworkFeeMode
-}
-
-func GetNetworkFeeMode() *NetworkFeeMode {
-	return &NetworkFeeMode{
-		MultiplePaymentsOnly: "MultiplePaymentsOnly",
-		Always:               "Always",
-		Never:                "Never",
-	}
-}
-
-type StoreResponse struct {
-	Name                         string               `json:"name"`
-	Website                      string               `json:"website"`
-	InvoiceExpiration            int64                `json:"invoiceExpiration"`
-	MonitoringExpiration         int64                `json:"monitoringExpiration"`
-	SpeedPolicy                  BTCPaySpeedPolicy    `json:"speedPolicy"`
-	LightningDescriptionTemplate string               `json:"lightningDescriptionTemplate,omitempty"`
-	PaymentTolerance             float64              `json:"paymentTolerance"`
-	AnyoneCanCreateInvoice       bool                 `json:"anyoneCanCreateInvoice"`
-	RequiresRefundEmail          bool                 `json:"requiresRefundEmail"`
-	LightningAmountInSatoshi     bool                 `json:"lightningAmountInSatoshi"`
-	LightningPrivateRouteHints   bool                 `json:"lightningPrivateRouteHints"`
-	OnChainWithLnInvoiceFallback bool                 `json:"onChainWithLnInvoiceFallback"`
-	RedirectAutomatically        bool                 `json:"redirectAutomatically"`
-	ShowRecommendedFee           bool                 `json:"showRecommendedFee"`
-	RecommendedFeeBlockTarget    int32                `json:"recommendedFeeBlockTarget"`
-	DefaultLang                  string               `json:"defaultLang"`
-	CustomLogo                   string               `json:"customLogo,omitempty"`
-	CustomCSS                    string               `json:"customCSS,omitempty"`
-	HtmlTitle                    string               `json:"htmlTitle,omitempty"`
-	NetworkFeeMode               BTCPayNetworkFeeMode `json:"networkFeeMode"`
-	PayJoinEnabled               bool                 `json:"payJoinEnabled"`
-	DefaultPaymentMethod         string               `json:"defaultPaymentMethod"`
-	ID                           StoreID              `json:"id"`
-}
 
 // View information about the available stores
 func (c *Client) GetStores(ctx context.Context) ([]*StoreResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores", c.URL)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes []*StoreResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
 	}
-	var dataRes []*StoreResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
-	}
 	return dataRes, statusCode, nil
-}
-
-type StoreRequest struct {
-	Name                         string               `json:"name"`
-	Website                      string               `json:"website,omitempty"`
-	InvoiceExpiration            int64                `json:"invoiceExpiration,omitempty"`
-	MonitoringExpiration         int64                `json:"monitoringExpiration,omitempty"`
-	SpeedPolicy                  BTCPaySpeedPolicy    `json:"speedPolicy,omitempty"`
-	LightningDescriptionTemplate string               `json:"lightningDescriptionTemplate,omitempty"`
-	PaymentTolerance             float64              `json:"paymentTolerance,omitempty"`
-	AnyoneCanCreateInvoice       bool                 `json:"anyoneCanCreateInvoice,omitempty"`
-	RequiresRefundEmail          bool                 `json:"requiresRefundEmail,omitempty"`
-	LightningAmountInSatoshi     bool                 `json:"lightningAmountInSatoshi,omitempty"`
-	LightningPrivateRouteHints   bool                 `json:"lightningPrivateRouteHints,omitempty"`
-	OnChainWithLnInvoiceFallback bool                 `json:"onChainWithLnInvoiceFallback,omitempty"`
-	RedirectAutomatically        bool                 `json:"redirectAutomatically,omitempty"`
-	ShowRecommendedFee           bool                 `json:"showRecommendedFee,omitempty"`
-	RecommendedFeeBlockTarget    int32                `json:"recommendedFeeBlockTarget,omitempty"`
-	DefaultLang                  string               `json:"defaultLang,omitempty"`
-	CustomLogo                   string               `json:"customLogo,omitempty"`
-	CustomCSS                    string               `json:"customCSS,omitempty"`
-	HtmlTitle                    string               `json:"htmlTitle,omitempty"`
-	NetworkFeeMode               BTCPayNetworkFeeMode `json:"networkFeeMode,omitempty"`
-	PayJoinEnabled               bool                 `json:"payJoinEnabled,omitempty"`
-	DefaultPaymentMethod         string               `json:"defaultPaymentMethod,omitempty"`
 }
 
 // create a new store
 func (c *Client) CreateStore(ctx context.Context, storeRequest *StoreRequest) (*StoreResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores", c.URL)
-	dataReq, err := json.Marshal(storeRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes StoreResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "POST", &dataRes, storeRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes StoreResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
@@ -128,106 +30,40 @@ func (c *Client) CreateStore(ctx context.Context, storeRequest *StoreRequest) (*
 // View information about the specified store
 func (c *Client) GetStore(ctx context.Context, storeID *StoreID) (*StoreResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s", c.URL, *storeID)
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes StoreResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes StoreResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (s *Store) GetStore(ctx context.Context) (*StoreResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s", s.Client.URL, s.ID)
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes StoreResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes StoreResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
-type StoreUpdate struct {
-	Name                         string               `json:"name,omitempty"`
-	Website                      string               `json:"website,omitempty"`
-	InvoiceExpiration            int64                `json:"invoiceExpiration,omitempty"`
-	MonitoringExpiration         int64                `json:"monitoringExpiration,omitempty"`
-	SpeedPolicy                  BTCPaySpeedPolicy    `json:"speedPolicy,omitempty"`
-	LightningDescriptionTemplate string               `json:"lightningDescriptionTemplate,omitempty"`
-	PaymentTolerance             float64              `json:"paymentTolerance,omitempty"`
-	AnyoneCanCreateInvoice       bool                 `json:"anyoneCanCreateInvoice,omitempty"`
-	RequiresRefundEmail          bool                 `json:"requiresRefundEmail,omitempty"`
-	LightningAmountInSatoshi     bool                 `json:"lightningAmountInSatoshi,omitempty"`
-	LightningPrivateRouteHints   bool                 `json:"lightningPrivateRouteHints,omitempty"`
-	OnChainWithLnInvoiceFallback bool                 `json:"onChainWithLnInvoiceFallback,omitempty"`
-	RedirectAutomatically        bool                 `json:"redirectAutomatically,omitempty"`
-	ShowRecommendedFee           bool                 `json:"showRecommendedFee,omitempty"`
-	RecommendedFeeBlockTarget    int32                `json:"recommendedFeeBlockTarget,omitempty"`
-	DefaultLang                  string               `json:"defaultLang,omitempty"`
-	CustomLogo                   string               `json:"customLogo,omitempty"`
-	CustomCSS                    string               `json:"customCSS,omitempty"`
-	HtmlTitle                    string               `json:"htmlTitle,omitempty"`
-	NetworkFeeMode               BTCPayNetworkFeeMode `json:"networkFeeMode,omitempty"`
-	PayJoinEnabled               bool                 `json:"payJoinEnabled,omitempty"`
-	DefaultPaymentMethod         string               `json:"defaultPaymentMethod,omitempty"`
-	ID                           StoreID              `json:"id,omitempty"`
-}
-
 func (c *Client) UpdateStore(ctx context.Context, storeID *StoreID, storeUpdate *StoreUpdate) (*StoreResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s", c.URL, *storeID)
-	dataReq, err := json.Marshal(storeUpdate)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "PUT", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes StoreResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "PUT", &dataRes, storeUpdate)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes StoreResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
 func (s *Store) UpdateStore(ctx context.Context, storeUpdate *StoreUpdate) (*StoreResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s", s.Client.URL, s.ID)
-	dataReq, err := json.Marshal(storeUpdate)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "PUT", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := s.Client.doRequest(req)
+	var dataRes StoreResponse
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "PUT", &dataRes, storeUpdate)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes StoreResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
@@ -235,11 +71,7 @@ func (s *Store) UpdateStore(ctx context.Context, storeUpdate *StoreUpdate) (*Sto
 // Removes the specified store. If there is another user with access, only your access will be removed.
 func (c *Client) RemoveStore(ctx context.Context, storeID *StoreID) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s", c.URL, *storeID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := c.doRequest(req)
+	statusCode, err := c.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}
@@ -248,11 +80,7 @@ func (c *Client) RemoveStore(ctx context.Context, storeID *StoreID) (int, error)
 
 func (s *Store) RemoveStore(ctx context.Context) (int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/stores/%s", s.Client.URL, s.ID)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
-	if err != nil {
-		return 0, err
-	}
-	_, statusCode, err := s.Client.doRequest(req)
+	statusCode, err := s.Client.doRequest(ctx, endpoint, "DELETE", nil, nil)
 	if err != nil {
 		return statusCode, err
 	}

--- a/users.go
+++ b/users.go
@@ -1,67 +1,27 @@
 package btcpay
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
-
-type UserID string
-
-type UserResponse struct {
-	ID                        UserID   `json:"id"`
-	Email                     string   `json:"email"`
-	EmailConfirmed            bool     `json:"emailConfirmed"`
-	RequiresEmailConfirmation bool     `json:"requiresEmailConfirmation"`
-	Created                   int64    `json:"created,omitempty"`
-	Roles                     []string `json:"roles"`
-}
 
 // View information about the current user
 func (c *Client) GetUser(ctx context.Context) (*UserResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/users/me", c.URL)
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes UserResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes UserResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }
 
-type UserRequest struct {
-	Email           string `json:"email"`
-	Password        string `json:"password"`
-	IsAdministrator bool   `json:"isAdministrator"`
-}
-
 func (c *Client) CreateUser(ctx context.Context, userRequest *UserRequest) (*UserResponse, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/users", c.URL)
-	dataReq, err := json.Marshal(userRequest)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(dataReq))
-	if err != nil {
-		return nil, 0, err
-	}
-	bytes, statusCode, err := c.doRequest(req)
+	var dataRes UserResponse
+	statusCode, err := c.doRequest(ctx, endpoint, "POST", &dataRes, &userRequest)
 	if err != nil {
 		return nil, statusCode, err
-	}
-	var dataRes UserResponse
-	err = json.Unmarshal(bytes, &dataRes)
-	if err != nil {
-		return nil, 0, err
 	}
 	return &dataRes, statusCode, nil
 }


### PR DESCRIPTION
Use an interface argument in the request function. Allows to reuse more code, no need to unmarshall the json inside the separate functions.